### PR TITLE
minor typo correction

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,9 +68,9 @@
         <p>What about some code <strong>in</strong> a list? That's insane, right?</p>
         <ol>
         <li><p>In Ruby you can map like this:</p>
-        <pre><code>['a', 'b'].map { |x| x.uppercase }</code></pre></li>
+        <pre><code>['a', 'b'].map { |x| x.upcase }</code></pre></li>
         <li><p>In Rails, you can do a shortcut:</p>
-        <pre><code>['a', 'b'].map(&amp;:uppercase)</code></pre></li>
+        <pre><code>['a', 'b'].map(&amp;:upcase)</code></pre></li>
         </ol>
         <p>Some people seem to like definition lists</p>
         <dl>


### PR DESCRIPTION
Correct minor typo. In the Ruby and Rails examples, uppercase should be upcase.
